### PR TITLE
added support to delete the eip associated with ec2 and protection regarding prefix length

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*.*"  # Trigger on version tags like v1.0.0
 
+permissions:
+  contents: write
+
 jobs:
   build-and-publish:
     name: Build and Publish to PyPI

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="awsdeleter",
-    version="0.1.0",
+    version="0.1.1",
     description="A CLI tool to search and delete AWS EC2, S3, and VPC resources by prefix",
     author="Omkar Khatavkar",
     author_email="okhatavkar007@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="awsdeleter",
-    version="0.1.1",
+    version="0.1.2",
     description="A CLI tool to search and delete AWS EC2, S3, and VPC resources by prefix",
     author="Omkar Khatavkar",
     author_email="okhatavkar007@gmail.com",


### PR DESCRIPTION
## PR Title
Fix: Disassociate and release EIP before terminating EC2 and prefix length check

## Description
This update ensures that Elastic IPs (EIPs) associated with EC2 instances are disassociated before attempting to release them. This avoids `InvalidIPAddress.InUse` errors that occur when trying to release an EIP still attached to a running or stopping instance.

## Changes
- Added disassociation step using `disassociate_address`
- Released EIP using `release_address` only after disassociation
- Terminated EC2 instance after EIP cleanup

## Verification
Tested the flow to confirm:
- EIPs are successfully disassociated and released
- EC2 instances are terminated without errors